### PR TITLE
Support change in dbt 1.4 onwards to default adapter. Supports synapse or fabric adapters instead of sqlserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ The synapse `insert_by_timeperiod` materialisation includes a couple of differen
 
 ## Installation
 
-This is not a package on the Package Hub. To install it via git, add this to `packages.yml`:
+This is a package on the Package Hub. 
+
+```
+packages:
+	- package: alittlesliceoftom/insert_by_timeperiod 
+	  version: 0.1.3
+```
+
+Alternatively to install it via git, add this to `packages.yml`:
 
 ```yaml
 packages:

--- a/macros/insert_by_timeperiod_materialization.sql
+++ b/macros/insert_by_timeperiod_materialization.sql
@@ -1,5 +1,5 @@
 
-{% materialization insert_by_timeperiod, adapter = 'sqlserver' -%}
+{% materialization insert_by_timeperiod -%}
     {# {{ dbt_utils.log_info("Insert by time period called:") }} -- uncomment for debugging  #}
 
     {%- set full_refresh_mode = flags.FULL_REFRESH -%}

--- a/macros/insert_by_timeperiod_materialization.sql
+++ b/macros/insert_by_timeperiod_materialization.sql
@@ -1,5 +1,5 @@
 
-{% materialization insert_by_timeperiod -%}
+{% materialization insert_by_timeperiod, default -%}
     {# {{ dbt_utils.log_info("Insert by time period called:") }} -- uncomment for debugging  #}
 
     {%- set full_refresh_mode = flags.FULL_REFRESH -%}


### PR DESCRIPTION
This change enables users to use dbt 1.5-1.8